### PR TITLE
Benchmark Xoodoo[12] Permutation

### DIFF
--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -1,4 +1,8 @@
+#include "bench/bench_xoodoo.hpp"
 #include "bench/bench_xoodyak.hpp"
+
+// Register for benchmarking Xoodoo[12] Permutation
+BENCHMARK(bench_xoodyak::xoodoo);
 
 // Register Xoodyak cryptographic hash function for benchmark with specified
 // size of input message bytes

--- a/include/bench/bench_xoodoo.hpp
+++ b/include/bench/bench_xoodoo.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include "utils.hpp"
+#include "xoodoo.hpp"
+#include <benchmark/benchmark.h>
+
+// Benchmark Xoodyak Authenticated Encryption with Associated Data ( AEAD )
+namespace bench_xoodyak {
+
+// Benchmarks 12 rounds of Xoodoo permutation
+inline void
+xoodoo(benchmark::State& state)
+{
+  uint32_t st[12]{};
+  xoodyak_utils::random_data(st, 12);
+
+  for (auto _ : state) {
+    xoodoo::permute(st);
+
+    benchmark::DoNotOptimize(st);
+    benchmark::ClobberMemory();
+  }
+
+  state.SetBytesProcessed(sizeof(st) * state.iterations());
+}
+
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <random>
 #include <sstream>
+#include <type_traits>
 
 // Utility functions used in Xoodyak AEAD
 namespace xoodyak_utils {
@@ -68,13 +69,15 @@ to_hex(const uint8_t* const bytes, const size_t len)
   return ss.str();
 }
 
-// Generate `len` -many random 8 -bit unsigned integers
+// Generate `len` -many random elements of type T | T is unsigned integral
+template<typename T>
 inline void
-random_data(uint8_t* const data, const size_t len)
+random_data(T* const data, const size_t len)
+  requires(std::is_unsigned_v<T>)
 {
   std::random_device rd;
   std::mt19937_64 gen(rd());
-  std::uniform_int_distribution<uint8_t> dis;
+  std::uniform_int_distribution<T> dis;
 
   for (size_t i = 0; i < len; i++) {
     data[i] = dis(gen);


### PR DESCRIPTION
Benchmarks Xoodoo[12] permutation on target CPU, issue

```bash
make benchmark
```

---

```bash
2023-01-12T11:12:27+04:00
Running ./bench/a.out
Run on (8 X 2400 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB
  L1 Instruction 32 KiB
  L2 Unified 256 KiB (x4)
  L3 Unified 6144 KiB
Load Average: 2.28, 2.34, 2.24
-----------------------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------
bench_xoodyak::xoodoo                78.7 ns         78.6 ns      8520998 bytes_per_second=582.427M/s
```

```bash
2023-01-12T07:15:32+00:00
Running ./bench/a.out
Run on (48 X 2799.92 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 512 KiB (x24)
  L3 Unified 16384 KiB (x6)
Load Average: 0.00, 0.00, 0.00
-----------------------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------
bench_xoodyak::xoodoo                 103 ns          103 ns      6836404 bytes_per_second=446.479M/s
```

```bash
2023-01-12T07:16:37+00:00
Running ./bench/a.out
Run on (64 X 2100 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB (x64)
  L1 Instruction 64 KiB (x64)
  L2 Unified 1024 KiB (x64)
  L3 Unified 32768 KiB (x1)
Load Average: 0.00, 0.00, 0.00
-----------------------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------
bench_xoodyak::xoodoo                83.8 ns         83.8 ns      8345986 bytes_per_second=545.969M/s
```