### PR TITLE
Xoodoo[12] Permutation Using SSE2 Intrinsics

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -19,5 +19,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 9
     - name: Install Python dependencies
       run: python3 -m pip install -r wrapper/python/requirements.txt --user
-    - name: Execute Tests
+    - name: Execute Tests ( without SSE2 )
       run: make
+    - name: Execute Tests ( with SSE2 )
+      run: SSE2=1 make

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,12 @@ CXX = g++
 CXXFLAGS = -std=c++20 -Wall -Wextra -pedantic
 OPTFLAGS = -O3 -march=native -mtune=native
 IFLAGS = -I ./include
+DUSE_SSE2 = -DUSE_SSE2=$(or $(SSE2),0)
 
 all: test_aead test_kat
 
 test/a.out: test/main.cpp include/*.hpp include/test/*.hpp
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $< -o $@
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DUSE_SSE2) $< -o $@
 
 test_aead: test/a.out
 	./$<
@@ -21,12 +22,12 @@ format:
 	find . -name '*.cpp' -o -name '*.hpp' | xargs clang-format -i --style=Mozilla
 
 lib:
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) -fPIC --shared wrapper/xoodyak.cpp -o wrapper/libxoodyak.so
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DUSE_SSE2) -fPIC --shared wrapper/xoodyak.cpp -o wrapper/libxoodyak.so
 
 bench/a.out: bench/main.cpp include/*.hpp include/bench/*.hpp
 	# make sure you've google-benchmark globally installed;
 	# see https://github.com/google/benchmark/tree/60b16f1#installation
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $< -lbenchmark -o $@
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(IFLAGS) $(DUSE_SSE2) $< -lbenchmark -o $@
 
 benchmark: bench/a.out
 	./$<

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -1,4 +1,8 @@
+#include "bench/bench_xoodoo.hpp"
 #include "bench/bench_xoodyak.hpp"
+
+// Register for benchmarking Xoodoo[12] Permutation
+BENCHMARK(bench_xoodyak::xoodoo);
 
 // Register Xoodyak cryptographic hash function for benchmark with specified
 // size of input message bytes

--- a/example/xoodyak_aead.cpp
+++ b/example/xoodyak_aead.cpp
@@ -19,10 +19,10 @@ main()
   uint8_t* enc = static_cast<uint8_t*>(std::malloc(ct_len));
   uint8_t* dec = static_cast<uint8_t*>(std::malloc(ct_len));
 
-  random_data(key, knt_len);
-  random_data(nonce, knt_len);
-  random_data(data, ad_len);
-  random_data(txt, ct_len);
+  xoodyak_utils::random_data(key, knt_len);
+  xoodyak_utils::random_data(nonce, knt_len);
+  xoodyak_utils::random_data(data, ad_len);
+  xoodyak_utils::random_data(txt, ct_len);
 
   bool f = false;
 
@@ -35,6 +35,7 @@ main()
     assert((txt[i] ^ dec[i]) == 0u);
   }
 
+  using namespace xoodyak_utils;
   std::cout << "Xoodyak AEAD" << std::endl << std::endl;
   std::cout << "Key                : " << to_hex(key, knt_len) << std::endl;
   std::cout << "Nonce              : " << to_hex(nonce, knt_len) << std::endl;

--- a/example/xoodyak_hash.cpp
+++ b/example/xoodyak_hash.cpp
@@ -13,10 +13,11 @@ main()
   uint8_t* msg = static_cast<uint8_t*>(std::malloc(msg_len));
   uint8_t* out = static_cast<uint8_t*>(std::malloc(xoodyak::DIGEST_LEN));
 
-  random_data(msg, msg_len);
+  xoodyak_utils::random_data(msg, msg_len);
 
   xoodyak::hash(msg, msg_len, out);
 
+  using namespace xoodyak_utils;
   std::cout << "Message         : " << to_hex(msg, msg_len) << std::endl;
   std::cout << "Xoodyak Digest  : " << to_hex(out, xoodyak::DIGEST_LEN)
             << std::endl;

--- a/include/bench/bench_xoodoo.hpp
+++ b/include/bench/bench_xoodoo.hpp
@@ -10,7 +10,10 @@ namespace bench_xoodyak {
 inline void
 xoodoo(benchmark::State& state)
 {
-  uint32_t st[12]{};
+#if defined __SSE2__
+  alignas(16)
+#endif
+    uint32_t st[12]{};
   xoodyak_utils::random_data(st, 12);
 
   for (auto _ : state) {

--- a/include/bench/bench_xoodoo.hpp
+++ b/include/bench/bench_xoodoo.hpp
@@ -10,7 +10,7 @@ namespace bench_xoodyak {
 inline void
 xoodoo(benchmark::State& state)
 {
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
   alignas(16)
 #endif
     uint32_t st[12]{};

--- a/include/bench/bench_xoodoo.hpp
+++ b/include/bench/bench_xoodoo.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include "utils.hpp"
+#include "xoodoo.hpp"
+#include <benchmark/benchmark.h>
+
+// Benchmark Xoodyak Authenticated Encryption with Associated Data ( AEAD )
+namespace bench_xoodyak {
+
+// Benchmarks 12 rounds of Xoodoo permutation
+inline void
+xoodoo(benchmark::State& state)
+{
+  uint32_t st[12]{};
+  xoodyak_utils::random_data(st, 12);
+
+  for (auto _ : state) {
+    xoodoo::permute(st);
+
+    benchmark::DoNotOptimize(st);
+    benchmark::ClobberMemory();
+  }
+
+  state.SetBytesProcessed(sizeof(st) * state.iterations());
+}
+
+}

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <random>
 #include <sstream>
+#include <type_traits>
 
 // Utility functions used in Xoodyak AEAD
 namespace xoodyak_utils {
@@ -68,13 +69,15 @@ to_hex(const uint8_t* const bytes, const size_t len)
   return ss.str();
 }
 
-// Generate `len` -many random 8 -bit unsigned integers
+// Generate `len` -many random elements of type T | T is unsigned integral
+template<typename T>
 inline void
-random_data(uint8_t* const data, const size_t len)
+random_data(T* const data, const size_t len)
+  requires(std::is_unsigned_v<T>)
 {
   std::random_device rd;
   std::mt19937_64 gen(rd());
-  std::uniform_int_distribution<uint8_t> dis;
+  std::uniform_int_distribution<T> dis;
 
   for (size_t i = 0; i < len; i++) {
     data[i] = dis(gen);

--- a/include/xoodoo.hpp
+++ b/include/xoodoo.hpp
@@ -6,6 +6,8 @@
 #include <cstring>
 
 #if defined __SSE2__ && USE_SSE2 != 0
+// SSE intrinsics are defined on
+// https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#techs=SSE_ALL
 #include <emmintrin.h>
 #pragma message("Using SSE2 for Xoodoo[12] Permutation")
 #endif

--- a/include/xoodoo.hpp
+++ b/include/xoodoo.hpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <cstring>
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
 #include <emmintrin.h>
 #pragma message("Using SSE2 for Xoodoo[12] Permutation")
 #endif
@@ -31,7 +31,7 @@ check_lane_shift_factor(const int t)
   return (t == 0) || (t == 1) || (t == 2);
 }
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
 
 // Given a 128 -bit wide plane of Xoodoo permutation state ( each plane has 4
 // lanes, each lane of 32 -bit ), this function cyclically shifts the plane such
@@ -159,7 +159,7 @@ cyclic_shift(uint32_t* const plane)
 
 #endif
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
 
 // θ step mapping of Xoodoo permutation, as described in algorithm 1 of Xoodyak
 // specification
@@ -258,7 +258,7 @@ theta(uint32_t* const state)
 
 #endif
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
 
 // ρ step mapping function of Xoodoo permutation, which is templated so that it
 // can act as both `ρ_east` and `ρ_west`, implemented using SSE2 vector
@@ -292,7 +292,7 @@ rho(uint32_t* const state)
 
 #endif
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
 
 // ι step mapping function of Xoodoo permutation, where single round constant is
 // XORed into first lane ( x = 0 ) of first plane ( y = 0 ) of internal state,
@@ -326,7 +326,7 @@ iota(uint32_t* const state, const size_t r_idx)
 
 #endif
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
 
 // χ step mapping function of Xoodoo permutation, which is a non-linear layer
 // applied on state during permutation round, using SSE2 vector intrinsics.
@@ -434,7 +434,7 @@ chi(uint32_t* const state)
 
 #endif
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
 
 // Single round ( which specific round it is, denoted by `r_idx` ∈ [0, 12) ) of
 // Xoodoo permutation, which applies following step mappings on state, in order
@@ -491,7 +491,7 @@ round(uint32_t* const state, const size_t r_idx)
 
 #endif
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
 
 // Xoodoo permutation function, where 12 rounds of Xoodoo round function is
 // applied on internal state, using SSE2 intrinsics.

--- a/include/xoodoo.hpp
+++ b/include/xoodoo.hpp
@@ -257,6 +257,25 @@ theta(uint32_t* const state)
 
 #endif
 
+#if defined __SSE2__
+
+// ρ step mapping function of Xoodoo permutation, which is templated so that it
+// can act as both `ρ_east` and `ρ_west`, implemented using SSE2 vector
+// intrinsics.
+//
+// See algorithm 1 of Xoodyak specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/xoodyak-spec-final.pdf
+template<const size_t t1, const size_t v1, const size_t t2, const size_t v2>
+static inline std::array<__m128i, 3>
+rho(std::array<const __m128i, 3> state)
+{
+  return { state[0],
+           cyclic_shift<t1, v1>(state[1]),
+           cyclic_shift<t2, v2>(state[2]) };
+}
+
+#else
+
 // ρ step mapping function of Xoodoo permutation, which is templated so that it
 // can act as both `ρ_east` and `ρ_west`
 //
@@ -269,6 +288,8 @@ rho(uint32_t* const state)
   cyclic_shift<t1, v1>(state + 4);
   cyclic_shift<t2, v2>(state + 8);
 }
+
+#endif
 
 // ι step mapping function of Xoodoo permutation, where round constant is XORed
 // into first lane ( x = 0 ) of first plane ( y = 0 ) of internal state

--- a/include/xoodyak.hpp
+++ b/include/xoodyak.hpp
@@ -28,7 +28,7 @@ hash(const uint8_t* const __restrict msg, // N -bytes input message to be hashed
 {
   cyclist::phase_t ph = cyclist::phase_t::Up;
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
   alignas(16)
 #endif
     uint32_t state[12]{};
@@ -55,7 +55,7 @@ encrypt(const uint8_t* const __restrict key,   // 128 -bit secret key
 {
   cyclist::phase_t ph = cyclist::phase_t::Up;
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
   alignas(16)
 #endif
     uint32_t state[12]{};
@@ -86,7 +86,7 @@ decrypt(const uint8_t* const __restrict key,   // 128 -bit secret key
 {
   cyclist::phase_t ph = cyclist::phase_t::Up;
 
-#if defined __SSE2__
+#if defined __SSE2__ && USE_SSE2 != 0
   alignas(16)
 #endif
     uint32_t state[12]{};

--- a/include/xoodyak.hpp
+++ b/include/xoodyak.hpp
@@ -27,7 +27,11 @@ hash(const uint8_t* const __restrict msg, // N -bytes input message to be hashed
 )
 {
   cyclist::phase_t ph = cyclist::phase_t::Up;
-  uint32_t state[12]{};
+
+#if defined __SSE2__
+  alignas(16)
+#endif
+    uint32_t state[12]{};
 
   cyclist::absorb<cyclist::mode_t::Hash>(state, msg, m_len, &ph);
   cyclist::squeeze<cyclist::mode_t::Hash>(state, out, DIGEST_LEN, &ph);
@@ -50,7 +54,11 @@ encrypt(const uint8_t* const __restrict key,   // 128 -bit secret key
 )
 {
   cyclist::phase_t ph = cyclist::phase_t::Up;
-  uint32_t state[12]{};
+
+#if defined __SSE2__
+  alignas(16)
+#endif
+    uint32_t state[12]{};
 
   cyclist::absorb_key(state, key, nonce, &ph);
   cyclist::absorb<cyclist::mode_t::Keyed>(state, data, dt_len, &ph);
@@ -77,7 +85,11 @@ decrypt(const uint8_t* const __restrict key,   // 128 -bit secret key
 )
 {
   cyclist::phase_t ph = cyclist::phase_t::Up;
-  uint32_t state[12]{};
+
+#if defined __SSE2__
+  alignas(16)
+#endif
+    uint32_t state[12]{};
   uint8_t tag_[16]{};
 
   cyclist::absorb_key(state, key, nonce, &ph);


### PR DESCRIPTION
Adds support for using SSE2 intrinsics when applying Xoodoo[12] permutation. 

For testing SSE2 implementation

```bash
SSE2=1 make
```

For benchmarking SSE2 implementation

```bash
SSE2=1 make benchmark
```

---

Let's look at results

## Without SSE2 using GCC on Intel x86_64

```bash
2023-01-12T07:32:03+00:00
Running ./bench/a.out
Run on (128 X 1027.13 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x64)
  L1 Instruction 32 KiB (x64)
  L2 Unified 1280 KiB (x64)
  L3 Unified 55296 KiB (x2)
Load Average: 0.08, 0.02, 0.01
-----------------------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------
bench_xoodyak::xoodoo                 157 ns          157 ns      4455173 bytes_per_second=291.298M/s
```

## With SSE2 using GCC on Intel x86_64

```bash
2023-01-12T07:32:36+00:00
Running ./bench/a.out
Run on (128 X 1335.66 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x64)
  L1 Instruction 32 KiB (x64)
  L2 Unified 1280 KiB (x64)
  L3 Unified 55296 KiB (x2)
Load Average: 0.11, 0.03, 0.01
-----------------------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------
bench_xoodyak::xoodoo                 123 ns          123 ns      5685346 bytes_per_second=371.848M/s
```

## Without SSE2 using Clang on Intel x86_64

```bash
2023-01-12T07:33:52+00:00
Running ./bench/a.out
Run on (128 X 1349.75 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x64)
  L1 Instruction 32 KiB (x64)
  L2 Unified 1280 KiB (x64)
  L3 Unified 55296 KiB (x2)
Load Average: 0.13, 0.05, 0.01
-----------------------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------
bench_xoodyak::xoodoo                79.1 ns         79.1 ns      8849028 bytes_per_second=578.71M/s
```

## With SSE2 using Clang on Intel x86_64

```bash
2023-01-12T07:34:02+00:00
Running ./bench/a.out
Run on (128 X 1261.26 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x64)
  L1 Instruction 32 KiB (x64)
  L2 Unified 1280 KiB (x64)
  L3 Unified 55296 KiB (x2)
Load Average: 0.18, 0.06, 0.02
-----------------------------------------------------------------------------------------
Benchmark                               Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------
bench_xoodyak::xoodoo                 116 ns          116 ns      6049088 bytes_per_second=395.593M/s
```